### PR TITLE
[#65] T셀파 API로부터 유사 문제 리스트를 받아 오는 기능 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
                         string(credentialsId: 'TSHERPA_API_GET_ITEMS_URL', variable: 'TSHERPA_API_GET_ITEMS_URL'),
                         string(credentialsId: 'TSHERPA_API_GET_CHAPTER_ITEMS_URL', variable: 'TSHERPA_API_GET_CHAPTER_ITEMS_URL'),
                         string(credentialsId: 'TSHERPA_API_GET_EXAM_ITEMS_URL', variable: 'TSHERPA_API_GET_EXAM_ITEMS_URL')
+                        string(credentialsId: 'TSHERPA_API_GET_SIMILAR_ITEMS_URL', variable: 'TSHERPA_API_GET_SIMILAR_ITEMS_URL')
                     ]) {
                         sh '''
                         #!/bin/bash
@@ -112,6 +113,7 @@ pipeline {
                             export TSHERPA_API_GET_ITEMS_URL='$TSHERPA_API_GET_ITEMS_URL'
                             export TSHERPA_API_GET_CHAPTER_ITEMS_URL='$TSHERPA_API_GET_CHAPTER_ITEMS_URL'
                             export TSHERPA_API_GET_EXAM_ITEMS_URL='$TSHERPA_API_GET_EXAM_ITEMS_URL'
+                            export TSHERPA_API_GET_SIMILAR_ITEMS_URL='$TSHERPA_API_GET_SIMILAR_ITEMS_URL'
 
                             docker stop \$PROJECT_NAME || true
                             docker rm \$PROJECT_NAME || true

--- a/src/main/java/bgaebalja/bsherpa/client/item/GetItemsRequest.java
+++ b/src/main/java/bgaebalja/bsherpa/client/item/GetItemsRequest.java
@@ -12,7 +12,7 @@ public class GetItemsRequest {
         this.itemIdList = itemIdList;
     }
 
-    public static GetItemsRequest from(List<String> itemIds) {
+    public static GetItemsRequest of(List<String> itemIds) {
         return new GetItemsRequest(itemIds);
     }
 }

--- a/src/main/java/bgaebalja/bsherpa/client/item/GetSimilarItemsRequest.java
+++ b/src/main/java/bgaebalja/bsherpa/client/item/GetSimilarItemsRequest.java
@@ -1,0 +1,20 @@
+package bgaebalja.bsherpa.client.item;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetSimilarItemsRequest {
+    private List<String> itemIdList;
+    private List<String> excludeCode;
+
+    public GetSimilarItemsRequest(List<String> itemIdList, List<String> excludeCode) {
+        this.itemIdList = itemIdList;
+        this.excludeCode = excludeCode;
+    }
+
+    public static GetSimilarItemsRequest of(List<String> itemIds, List<String> excludedItemIds) {
+        return new GetSimilarItemsRequest(itemIds, excludedItemIds);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/client/item/ItemApiClient.java
+++ b/src/main/java/bgaebalja/bsherpa/client/item/ItemApiClient.java
@@ -31,6 +31,9 @@ public class ItemApiClient {
     @Value("${tsherpa.api.get-exam-items.url}")
     private String getExamItemsUrl;
 
+    @Value("${tsherpa.api.get-similar-items.url}")
+    private String getSimilarItemsUrl;
+
     private static final String EXAM_ID = "examId";
 
     public GetItemsResponse getItems(GetItemsRequest getItemsRequest) {
@@ -76,6 +79,24 @@ public class ItemApiClient {
         headers.set(CONTENT_TYPE, APPLICATION_JSON);
 
         HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(Map.of(EXAM_ID, examId), headers);
+
+        ResponseEntity<GetItemsResponse> responseEntity = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                requestEntity,
+                GetItemsResponse.class
+        );
+
+        return responseEntity.getBody();
+    }
+
+    public GetItemsResponse getSimilarItems(GetSimilarItemsRequest getSimilarItemsRequest) {
+        String url = String.format("%s/%s", tsherpaUrl, getSimilarItemsUrl);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(CONTENT_TYPE, APPLICATION_JSON);
+
+        HttpEntity<GetSimilarItemsRequest> requestEntity = new HttpEntity<>(getSimilarItemsRequest, headers);
 
         ResponseEntity<GetItemsResponse> responseEntity = restTemplate.exchange(
                 url,

--- a/src/main/java/bgaebalja/bsherpa/question/controller/QuestionExternalController.java
+++ b/src/main/java/bgaebalja/bsherpa/question/controller/QuestionExternalController.java
@@ -1,9 +1,6 @@
 package bgaebalja.bsherpa.question.controller;
 
-import bgaebalja.bsherpa.client.item.GetChapterItemsRequest;
-import bgaebalja.bsherpa.client.item.GetItemsRequest;
-import bgaebalja.bsherpa.client.item.GetItemsResponse;
-import bgaebalja.bsherpa.client.item.ItemApiClient;
+import bgaebalja.bsherpa.client.item.*;
 import bgaebalja.bsherpa.util.FormatValidator;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -34,9 +31,15 @@ public class QuestionExternalController {
 
     private static final String GET_EXAM_ITEMS_FROM_TSHERPA = "T셀파의 시험지 별 문제 목록 조회";
     private static final String GET_EXAM_ITEMS_FROM_TSHERPA_DESCRIPTION
-            = "시험지 별 문제 목록 조회 양식을 입력해 T셀파의 문제 목록을 조회할 수 있습니다.";
+            = "시험지 ID를 입력해 T셀파의 문제 목록을 조회할 수 있습니다.";
     private static final String TSHERPA_EXAM_ID = "T셀파의 시험지 ID";
     private static final String TSHERPA_EXAM_ID_EXAMPLE = "1534";
+
+    private static final String GET_SIMILAR_ITEMS_FROM_TSHERPA = "T셀파의 유사 문제 목록 조회";
+    private static final String GET_SIMILAR_ITEMS_FROM_TSHERPA_DESCRIPTION
+            = "문제 ID 목록과 제외할 문제 ID 목록을 입력해 T셀파의 유사 문제 목록을 조회할 수 있습니다.";
+    private static final String TSHERPA_EXCLUDED_ITEM_IDS = "T셀파의 제외할 문제 ID 목록";
+    private static final String TSHERPA_EXCLUDED_ITEM_IDS_EXAMPLE = "206643, 259853";
 
     @GetMapping()
     @ApiOperation(value = GET_ITEMS_FROM_TSHERPA, notes = GET_ITEMS_FROM_TSHERPA_DESCRIPTION)
@@ -46,7 +49,7 @@ public class QuestionExternalController {
     ) {
         itemIds.stream().forEach(FormatValidator::validatePositiveInteger);
 
-        return ResponseEntity.status(OK).body(itemApiClient.getItems(GetItemsRequest.from(itemIds)));
+        return ResponseEntity.status(OK).body(itemApiClient.getItems(GetItemsRequest.of(itemIds)));
     }
 
     @PostMapping("/chapters")
@@ -64,11 +67,27 @@ public class QuestionExternalController {
     @GetMapping("/exam")
     @ApiOperation(value = GET_EXAM_ITEMS_FROM_TSHERPA, notes = GET_EXAM_ITEMS_FROM_TSHERPA_DESCRIPTION)
     public ResponseEntity<GetItemsResponse> getExamItemsFromTsherpa(
-            @ApiParam(value = TSHERPA_EXAM_ID, defaultValue = TSHERPA_EXAM_ID_EXAMPLE)
+            @ApiParam(value = TSHERPA_EXAM_ID, example = TSHERPA_EXAM_ID_EXAMPLE)
             @RequestParam String examId
     ) {
         FormatValidator.validatePositiveInteger(examId);
 
         return ResponseEntity.status(OK).body(itemApiClient.getExamItems(examId));
+    }
+
+    @GetMapping("/similar-items")
+    @ApiOperation(value = GET_SIMILAR_ITEMS_FROM_TSHERPA, notes = GET_SIMILAR_ITEMS_FROM_TSHERPA_DESCRIPTION)
+    public ResponseEntity<GetItemsResponse> getExamItemsFromTsherpa(
+            @ApiParam(value = TSHERPA_ITEM_IDS, defaultValue = TSHERPA_ITEM_IDS_EXAMPLE)
+            @RequestParam List<String> itemIds,
+            @ApiParam(value = TSHERPA_EXCLUDED_ITEM_IDS, defaultValue = TSHERPA_EXCLUDED_ITEM_IDS_EXAMPLE)
+            @RequestParam List<String> excludedItemIds
+    ) {
+        itemIds.stream().forEach(FormatValidator::validatePositiveInteger);
+        excludedItemIds.stream().forEach(FormatValidator::validatePositiveInteger);
+
+        return ResponseEntity.status(OK).body(
+                itemApiClient.getSimilarItems(GetSimilarItemsRequest.of(itemIds, excludedItemIds))
+        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,8 @@ tsherpa:
       url: ${TSHERPA_API_GET_CHAPTER_ITEMS_URL}
     get-exam-items:
       url: ${TSHERPA_API_GET_EXAM_ITEMS_URL}
+    get-similar-items:
+      url: ${TSHERPA_API_GET_SIMILAR_ITEMS_URL}
 management:
   endpoints:
     web:


### PR DESCRIPTION
## resolve #65

## 추가사항
- 유사 문제 ID 목록과 제외할 문제 ID 목록을 통한 문제 리스트 요청
- 요청 객체를 직렬화해 T셀파 API에 요청
- API 응답을 Java 객체로 역직렬화
- 200 status code 응답

## 배포
- [ ] 성공
- [ ] 실패