### PR TITLE
[#82, #114] T셀파 API로부터 소단원과 토픽단원 별 문제 수 목록을 받아 오는 기능의 커리큘럼 코드와 교재 ID를 제외한 ID의 유효성 검사 제거

### DIFF
--- a/src/main/java/bgaebalja/bsherpa/question/controller/QuestionExternalController.java
+++ b/src/main/java/bgaebalja/bsherpa/question/controller/QuestionExternalController.java
@@ -108,9 +108,6 @@ public class QuestionExternalController {
     ) {
         FormatValidator.validatePositiveInteger(getItemCountsRequest.getCurriculumCode());
         FormatValidator.validatePositiveInteger(getItemCountsRequest.getSubjectId());
-        FormatValidator.validatePositiveInteger(getItemCountsRequest.getLargeChapterId());
-        FormatValidator.validatePositiveInteger(getItemCountsRequest.getMediumChapterId());
-        FormatValidator.validatePositiveInteger(getItemCountsRequest.getSmallChapterId());
 
         return ResponseEntity.status(OK).body(itemImageApiClient.getItemCounts(getItemCountsRequest));
     }


### PR DESCRIPTION
## resolve #114
## related to #82

## 변경사항
- QuestionExternalController 클래스

## 배포
- [x] 성공
- [ ] 실패