### PR TITLE
[#123] AWS S3와 데이터베이스에 파일을 저장, 조회하는 기능, 오류 신고 기능 추가

### DIFF
--- a/src/main/java/bgaebalja/bsherpa/erorreport/controller/ErrorReportController.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/controller/ErrorReportController.java
@@ -1,0 +1,37 @@
+package bgaebalja.bsherpa.erorreport.controller;
+
+import bgaebalja.bsherpa.erorreport.domain.RegisterErrorReportRequest;
+import bgaebalja.bsherpa.erorreport.service.ErrorReportService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequestMapping("/error-reports")
+@RequiredArgsConstructor
+public class ErrorReportController {
+    private final ErrorReportService errorReportService;
+
+    private static final String REGISTER_ERROR_REPORT = "문항 오류 신고 등록";
+    private static final String REGISTER_ERROR_REPORT_DESCRIPTION
+            = "오류 유형과 오류 이미지, 오류 신고 내용을 입력해 문항 오류 신고를 등록할 수 있습니다.";
+    private static final String REGISTER_ERROR_REPORT_FORM = "문항 오류 신고 등록 양식";
+
+    @PostMapping()
+    @ApiOperation(value = REGISTER_ERROR_REPORT, notes = REGISTER_ERROR_REPORT_DESCRIPTION)
+    public ResponseEntity<Void> registerQuestion(
+            @ApiParam(value = REGISTER_ERROR_REPORT_FORM)
+            @ModelAttribute RegisterErrorReportRequest registerErrorReportRequest
+    ) {
+        errorReportService.createErrorReport(registerErrorReportRequest);
+
+        return ResponseEntity.status(CREATED).build();
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/domain/ErrorReport.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/domain/ErrorReport.java
@@ -1,0 +1,28 @@
+package bgaebalja.bsherpa.erorreport.domain;
+
+import bgaebalja.bsherpa.audit.BaseGeneralEntity;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class ErrorReport extends BaseGeneralEntity {
+    @Column(nullable = false, length = 20)
+    private String type;
+
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    private ErrorReport(String type, String content) {
+        this.type = type;
+        this.content = content;
+    }
+
+    public static ErrorReport from(RegisterErrorReportRequest registerErrorReportRequest) {
+        return new ErrorReport(registerErrorReportRequest.getType(), registerErrorReportRequest.getContent());
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/domain/RegisterErrorReportRequest.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/domain/RegisterErrorReportRequest.java
@@ -1,0 +1,27 @@
+package bgaebalja.bsherpa.erorreport.domain;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class RegisterErrorReportRequest {
+    private static final String TYPE_VALUE = "오류 신고 유형";
+    private static final String TYPE_EXAMPLE = "문제오류";
+
+    private static final String IMAGE_VALUE = "이미지";
+
+    private static final String CONTENT_VALUE = "신고 내용";
+    private static final String CONTENT_EXAMPLE = "문제가 잘못되었습니다.";
+
+    @ApiModelProperty(value = TYPE_VALUE, example = TYPE_EXAMPLE)
+    private String type;
+
+    @ApiModelProperty(value = IMAGE_VALUE)
+    private MultipartFile image;
+
+    @ApiModelProperty(value = CONTENT_VALUE, example = CONTENT_EXAMPLE)
+    private String content;
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/repository/ErrorReportRepository.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/repository/ErrorReportRepository.java
@@ -1,0 +1,7 @@
+package bgaebalja.bsherpa.erorreport.repository;
+
+import bgaebalja.bsherpa.erorreport.domain.ErrorReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ErrorReportRepository extends JpaRepository<ErrorReport, Long> {
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/service/ErrorReportService.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/service/ErrorReportService.java
@@ -1,0 +1,7 @@
+package bgaebalja.bsherpa.erorreport.service;
+
+import bgaebalja.bsherpa.erorreport.domain.RegisterErrorReportRequest;
+
+public interface ErrorReportService {
+    void createErrorReport(RegisterErrorReportRequest registerErrorReportRequest);
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/service/ErrorReportServiceImpl.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/service/ErrorReportServiceImpl.java
@@ -1,0 +1,27 @@
+package bgaebalja.bsherpa.erorreport.service;
+
+import bgaebalja.bsherpa.erorreport.domain.ErrorReport;
+import bgaebalja.bsherpa.erorreport.domain.RegisterErrorReportRequest;
+import bgaebalja.bsherpa.erorreport.repository.ErrorReportRepository;
+import bgaebalja.bsherpa.file.domain.AddFileRequest;
+import bgaebalja.bsherpa.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+import static org.springframework.transaction.annotation.Propagation.NESTED;
+
+@Service
+@RequiredArgsConstructor
+public class ErrorReportServiceImpl implements ErrorReportService {
+    private final FileService fileService;
+    private final ErrorReportRepository errorReportRepository;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, propagation = NESTED, timeout = 20)
+    public void createErrorReport(RegisterErrorReportRequest registerErrorReportRequest) {
+        Long id = errorReportRepository.save(ErrorReport.from(registerErrorReportRequest)).getId();
+        fileService.createFile(AddFileRequest.from(registerErrorReportRequest, id.toString()));
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/exception/ExceptionMessage.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/ExceptionMessage.java
@@ -13,6 +13,8 @@ public class ExceptionMessage {
             = "시간값만 LocalDateTime 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String PARSING_BOOLEAN_EXCEPTION_MESSAGE
             = "논리형 값만 Boolean 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
+    public static final String INVALID_TARGET_TYPE_EXCEPTION_MESSAGE
+            = "존재하는 도메인만 TargetType으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
 
     public static final String TOKEN_NO_VALUE_EXCEPTION_MESSAGE = "로그인 후 다시 시도해 주세요.";
 

--- a/src/main/java/bgaebalja/bsherpa/exception/InvalidTargetTypeException.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/InvalidTargetTypeException.java
@@ -1,0 +1,7 @@
+package bgaebalja.bsherpa.exception;
+
+public class InvalidTargetTypeException extends InvalidValueException {
+    public InvalidTargetTypeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/controller/FileController.java
+++ b/src/main/java/bgaebalja/bsherpa/file/controller/FileController.java
@@ -1,0 +1,36 @@
+package bgaebalja.bsherpa.file.controller;
+
+import bgaebalja.bsherpa.file.domain.AddFileRequest;
+import bgaebalja.bsherpa.file.domain.AddFileResponse;
+import bgaebalja.bsherpa.file.domain.UserFile;
+import bgaebalja.bsherpa.file.service.FileService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@Controller
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class FileController {
+    private final FileService fileService;
+
+    private static final String ADD_FILE = "파일 추가";
+    private static final String ADD_FILE_DESCRIPTION = "파일과 대상 타입, 대상 ID를 입력해 파일을 추가할 수 있습니다.";
+    private static final String ADD_FILE_FORM = "파일 추가 양식";
+
+    @ApiOperation(value = ADD_FILE, notes = ADD_FILE_DESCRIPTION)
+    @PostMapping()
+    public ResponseEntity<AddFileResponse> addFile(
+            @ModelAttribute @Parameter(description = ADD_FILE_FORM) AddFileRequest addFileRequest
+    ) {
+        UserFile userFile = fileService.createFile(addFileRequest);
+        return ResponseEntity.status(CREATED).body(AddFileResponse.from(userFile));
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/domain/AddFileRequest.java
+++ b/src/main/java/bgaebalja/bsherpa/file/domain/AddFileRequest.java
@@ -1,0 +1,42 @@
+package bgaebalja.bsherpa.file.domain;
+
+import bgaebalja.bsherpa.erorreport.domain.RegisterErrorReportRequest;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import static bgaebalja.bsherpa.file.domain.TargetType.ERROR_REPORT;
+import static bgaebalja.bsherpa.util.RequestConstant.ID_EXAMPLE;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class AddFileRequest {
+    private static final String FILE_VALUE = "파일";
+
+    private static final String TARGET_TYPE_VALUE = "대상 타입";
+    private static final String TARGET_TYPE_EXAMPLE = "POST";
+
+    private static final String TARGET_ID_VALUE = "대상 ID";
+
+    @ApiModelProperty(value = FILE_VALUE)
+    private MultipartFile file;
+
+    @ApiModelProperty(value = TARGET_TYPE_VALUE, example = TARGET_TYPE_EXAMPLE)
+    private String targetType;
+
+    @ApiModelProperty(value = TARGET_ID_VALUE, example = ID_EXAMPLE)
+    private String targetId;
+
+    private AddFileRequest(MultipartFile file, String targetType, String targetId) {
+        this.file = file;
+        this.targetType = targetType;
+        this.targetId = targetId;
+    }
+
+    public static AddFileRequest from(RegisterErrorReportRequest registerErrorReportRequest, String id) {
+        return new AddFileRequest(registerErrorReportRequest.getImage(), ERROR_REPORT.name(), id);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/domain/AddFileResponse.java
+++ b/src/main/java/bgaebalja/bsherpa/file/domain/AddFileResponse.java
@@ -1,0 +1,18 @@
+package bgaebalja.bsherpa.file.domain;
+
+import lombok.Getter;
+
+@Getter
+public class AddFileResponse {
+    private Long id;
+    private String url;
+
+    private AddFileResponse(Long id, String url) {
+        this.id = id;
+        this.url = url;
+    }
+
+    public static AddFileResponse from(UserFile userFile) {
+        return new AddFileResponse(userFile.getId(), userFile.getS3Url());
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/domain/TargetType.java
+++ b/src/main/java/bgaebalja/bsherpa/file/domain/TargetType.java
@@ -1,0 +1,13 @@
+package bgaebalja.bsherpa.file.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TargetType {
+    EXAM_FILE("시험지 PDF 파일"),
+    ERROR_REPORT("오류 신고 이미지");
+
+    private final String description;
+}

--- a/src/main/java/bgaebalja/bsherpa/file/domain/UserFile.java
+++ b/src/main/java/bgaebalja/bsherpa/file/domain/UserFile.java
@@ -1,0 +1,39 @@
+package bgaebalja.bsherpa.file.domain;
+
+import bgaebalja.bsherpa.audit.BaseGeneralEntity;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class UserFile extends BaseGeneralEntity {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TargetType targetType;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Column(name = "s3_url", nullable = false, length = 500)
+    private String s3Url;
+
+    private UserFile(TargetType targetType, Long targetId, String s3Url) {
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.s3Url = s3Url;
+    }
+
+    public static UserFile of(TargetType targetType, Long targetId, String s3Url) {
+        return new UserFile(targetType, targetId, s3Url);
+    }
+
+    public String getS3Url() {
+        return s3Url;
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/exception/ExceptionMessage.java
+++ b/src/main/java/bgaebalja/bsherpa/file/exception/ExceptionMessage.java
@@ -1,0 +1,9 @@
+package bgaebalja.bsherpa.file.exception;
+
+public class ExceptionMessage {
+    public static final String S3_UPLOAD_FAILED_EXCEPTION_MESSAGE = "S3 업로드 과정에서 오류가 발생했습니다.";
+    public static final String FILE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 파일을 찾을 수 없습니다. 다시 시도해 주세요. 전송된 ID: %d";
+    public static final String TARGET_FILE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 파일을 찾을 수 없습니다. 다시 시도해 주세요. 전송된 대상 타입: %s, 전송된 대상 ID: %d";
+}

--- a/src/main/java/bgaebalja/bsherpa/file/exception/FileNotFoundException.java
+++ b/src/main/java/bgaebalja/bsherpa/file/exception/FileNotFoundException.java
@@ -1,0 +1,9 @@
+package bgaebalja.bsherpa.file.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class FileNotFoundException extends EntityNotFoundException {
+    public FileNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/exception/S3UploadFailedException.java
+++ b/src/main/java/bgaebalja/bsherpa/file/exception/S3UploadFailedException.java
@@ -1,0 +1,7 @@
+package bgaebalja.bsherpa.file.exception;
+
+public class S3UploadFailedException extends RuntimeException {
+    public S3UploadFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/file/repository/FileRepository.java
+++ b/src/main/java/bgaebalja/bsherpa/file/repository/FileRepository.java
@@ -1,0 +1,20 @@
+package bgaebalja.bsherpa.file.repository;
+
+import bgaebalja.bsherpa.file.domain.TargetType;
+import bgaebalja.bsherpa.file.domain.UserFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FileRepository extends JpaRepository<UserFile, Long> {
+    List<UserFile> findByTargetTypeAndTargetIdAndDeleteYnFalseOrderByCreatedAtDesc(TargetType targetType, Long id);
+
+    Optional<UserFile> findByIdAndDeleteYnFalse(Long id);
+
+    Optional<UserFile> findFirstByTargetTypeAndTargetIdAndDeleteYnFalseOrderByCreatedAt(
+            TargetType targetType, Long targetId
+    );
+
+    List<UserFile> findByTargetId(Long targetId);
+}

--- a/src/main/java/bgaebalja/bsherpa/file/service/FileService.java
+++ b/src/main/java/bgaebalja/bsherpa/file/service/FileService.java
@@ -1,0 +1,13 @@
+package bgaebalja.bsherpa.file.service;
+
+import bgaebalja.bsherpa.file.domain.AddFileRequest;
+import bgaebalja.bsherpa.file.domain.TargetType;
+import bgaebalja.bsherpa.file.domain.UserFile;
+
+import java.util.List;
+
+public interface FileService {
+    UserFile createFile(AddFileRequest addFileRequest);
+
+    List<UserFile> getFiles(TargetType targetType, Long targetId);
+}

--- a/src/main/java/bgaebalja/bsherpa/file/service/FileServiceImpl.java
+++ b/src/main/java/bgaebalja/bsherpa/file/service/FileServiceImpl.java
@@ -1,0 +1,89 @@
+package bgaebalja.bsherpa.file.service;
+
+import bgaebalja.bsherpa.file.domain.AddFileRequest;
+import bgaebalja.bsherpa.file.domain.TargetType;
+import bgaebalja.bsherpa.file.domain.UserFile;
+import bgaebalja.bsherpa.file.exception.S3UploadFailedException;
+import bgaebalja.bsherpa.file.repository.FileRepository;
+import bgaebalja.bsherpa.util.FormatConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static bgaebalja.bsherpa.file.exception.ExceptionMessage.S3_UPLOAD_FAILED_EXCEPTION_MESSAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService {
+    private final FileRepository fileRepository;
+    private final S3Client s3Client;
+
+    private static final String TLS_HTTP_PROTOCOL = "https://";
+    private static final String S3_ADDRESS = "s3.amazonaws.com";
+    private static final String DEFAULT_FILE_URL
+            = "https://ddipddipddip.s3.amazonaws.com/post/1817/1729057414653_-2024-07-02-111008.png";
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String s3BucketName;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, timeout = 10)
+    public UserFile createFile(AddFileRequest addFileRequest) {
+        MultipartFile fileToUpload = addFileRequest.getFile();
+        TargetType targetType = FormatConverter.parseToTargetType(addFileRequest.getTargetType());
+        Long targetId = FormatConverter.parseToLong(addFileRequest.getTargetId());
+
+        List<UserFile> existingImages
+                = fileRepository.findByTargetTypeAndTargetIdAndDeleteYnFalseOrderByCreatedAtDesc(targetType, targetId);
+        UserFile userFile = UserFile.of(targetType, targetId, uploadToS3(fileToUpload, targetType, targetId));
+        fileRepository.save(userFile);
+
+        return userFile;
+    }
+
+    private String uploadToS3(MultipartFile file, TargetType targetType, Long productId) {
+        String sanitizedFilename = FormatConverter.sanitizeFileName(file.getOriginalFilename());
+        long ms = System.currentTimeMillis();
+        String key
+                = String.format("%s/%d/%s_%s", targetType.toString().toLowerCase(), productId, ms, sanitizedFilename);
+
+        try {
+            File tempFile = convertMultipartFileToFile(file);
+            s3Client.putObject(PutObjectRequest.builder()
+                    .bucket(s3BucketName)
+                    .key(key)
+                    .build(), Paths.get(tempFile.getPath()));
+            tempFile.delete();
+        } catch (IOException ie) {
+            throw new S3UploadFailedException(S3_UPLOAD_FAILED_EXCEPTION_MESSAGE, ie);
+        }
+
+        return String.format("%s%s.%s/%s", TLS_HTTP_PROTOCOL, s3BucketName, S3_ADDRESS, key);
+    }
+
+    private File convertMultipartFileToFile(MultipartFile file) throws IOException {
+        File convertedFile
+                = new File(String.format("%s/%s", System.getProperty("java.io.tmpdir"), file.getOriginalFilename()));
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        }
+        return convertedFile;
+    }
+
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
+    @Override
+    public List<UserFile> getFiles(TargetType targetType, Long targetId) {
+        return fileRepository.findByTargetTypeAndTargetIdAndDeleteYnFalseOrderByCreatedAtDesc(targetType, targetId);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/security/filter/JwtCheckFilter.java
+++ b/src/main/java/bgaebalja/bsherpa/security/filter/JwtCheckFilter.java
@@ -48,6 +48,9 @@ public class JwtCheckFilter extends OncePerRequestFilter {
     if (path.startsWith("/step1/chapters")) {
       return true;
     }
+    if (path.startsWith("/error-reports")) {
+      return true;
+    }
     if (path.startsWith("/swagger-ui/") ||
         path.startsWith("/v2/api-docs") ||
         path.startsWith("/configuration/security")||

--- a/src/main/java/bgaebalja/bsherpa/util/FormatConverter.java
+++ b/src/main/java/bgaebalja/bsherpa/util/FormatConverter.java
@@ -1,6 +1,7 @@
 package bgaebalja.bsherpa.util;
 
 import bgaebalja.bsherpa.exception.*;
+import bgaebalja.bsherpa.file.domain.TargetType;
 
 import static bgaebalja.bsherpa.exception.ExceptionMessage.*;
 
@@ -46,6 +47,14 @@ public class FormatConverter {
         }
 
         return Boolean.parseBoolean(value);
+    }
+
+    public static TargetType parseToTargetType(String targetType) {
+        try {
+            return TargetType.valueOf(targetType);
+        } catch (IllegalArgumentException iae) {
+            throw new InvalidTargetTypeException(String.format(INVALID_TARGET_TYPE_EXCEPTION_MESSAGE, targetType));
+        }
     }
 
     public static String sanitizeFileName(String filename) {

--- a/src/main/java/bgaebalja/bsherpa/util/RequestConstant.java
+++ b/src/main/java/bgaebalja/bsherpa/util/RequestConstant.java
@@ -7,6 +7,8 @@ public class RequestConstant {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String APPLICATION_JSON = "application/json";
 
+    public static final String ID_EXAMPLE = "1";
+
     public static final String EXAM_ID = "examId";
     public static final String SUBJECT_ID = "subjectId";
 }


### PR DESCRIPTION
## resolve #123

## 추가사항
- 파일 저장 요청
- 파일 저장 비즈니스 로직
- S3에 파일 저장
- 데이터베이스에 URL 저장
- 201 status code 응답
- 파일 목록 조회 비즈니스 로직
- 데이터베이스에서 파일 목록 조회

### 오류 신고
- 오류 신고 요청
- 오류 신고 비즈니스 로직
- 데이터베이스에 오류 신고 유형과 내용 저장
- 오류 신고 이미지를 S3와 파일 테이블에 저장
- 201 status code 응답

## 배포
- [ ] 성공
- [ ] 실패