### PR TITLE
[#127] Step2에서 오류 신고 시 동일 사용자가 중복된 오류 신고를 하면 409 CONFLICT 예외를 발생시키는 기능 추가

### DIFF
--- a/src/main/java/bgaebalja/bsherpa/erorreport/controller/ErrorReportController.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/controller/ErrorReportController.java
@@ -2,6 +2,7 @@ package bgaebalja.bsherpa.erorreport.controller;
 
 import bgaebalja.bsherpa.erorreport.domain.RegisterErrorReportRequest;
 import bgaebalja.bsherpa.erorreport.service.ErrorReportService;
+import bgaebalja.bsherpa.util.FormatValidator;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,8 @@ public class ErrorReportController {
             @ApiParam(value = REGISTER_ERROR_REPORT_FORM)
             @ModelAttribute RegisterErrorReportRequest registerErrorReportRequest
     ) {
+        FormatValidator.validateEmail(registerErrorReportRequest.getUserEmail());
+        FormatValidator.validatePositiveOrZeroInteger(registerErrorReportRequest.getItemId());
         errorReportService.createErrorReport(registerErrorReportRequest);
 
         return ResponseEntity.status(CREATED).build();

--- a/src/main/java/bgaebalja/bsherpa/erorreport/domain/ErrorReport.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/domain/ErrorReport.java
@@ -1,28 +1,47 @@
 package bgaebalja.bsherpa.erorreport.domain;
 
 import bgaebalja.bsherpa.audit.BaseGeneralEntity;
+import bgaebalja.bsherpa.user.domain.Users;
+import bgaebalja.bsherpa.util.FormatConverter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
+import static javax.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 public class ErrorReport extends BaseGeneralEntity {
+    @Column(nullable = false)
+    private Long itemId;
+
     @Column(nullable = false, length = 20)
     private String type;
 
     @Column(nullable = false, length = 200)
     private String content;
 
-    private ErrorReport(String type, String content) {
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reporter_id")
+    private Users reporter;
+
+    private ErrorReport(Long itemId, String type, String content, Users reporter) {
+        this.itemId = itemId;
         this.type = type;
         this.content = content;
+        this.reporter = reporter;
     }
 
-    public static ErrorReport from(RegisterErrorReportRequest registerErrorReportRequest) {
-        return new ErrorReport(registerErrorReportRequest.getType(), registerErrorReportRequest.getContent());
+    public static ErrorReport from(RegisterErrorReportRequest registerErrorReportRequest, Users reporter) {
+        return new ErrorReport(
+                FormatConverter.parseToLong(registerErrorReportRequest.getItemId()),
+                registerErrorReportRequest.getType(),
+                registerErrorReportRequest.getContent(),
+                reporter
+        );
     }
 }

--- a/src/main/java/bgaebalja/bsherpa/erorreport/domain/RegisterErrorReportRequest.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/domain/RegisterErrorReportRequest.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+import static bgaebalja.bsherpa.util.RequestConstant.*;
+
 @Getter
 @Setter
 public class RegisterErrorReportRequest {
@@ -15,6 +17,14 @@ public class RegisterErrorReportRequest {
 
     private static final String CONTENT_VALUE = "신고 내용";
     private static final String CONTENT_EXAMPLE = "문제가 잘못되었습니다.";
+
+    private static final String USER_EMAIL_VALUE = "회원 이메일 주소";
+
+    @ApiModelProperty(value = USER_EMAIL_VALUE, example = EMAIL_EXAMPLE)
+    private String userEmail;
+
+    @ApiModelProperty(value = ITEM_ID_VALUE, example = ITEM_ID_EXAMPLE)
+    private String itemId;
 
     @ApiModelProperty(value = TYPE_VALUE, example = TYPE_EXAMPLE)
     private String type;

--- a/src/main/java/bgaebalja/bsherpa/erorreport/exception/DuplicatedErrorReportException.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/exception/DuplicatedErrorReportException.java
@@ -1,0 +1,9 @@
+package bgaebalja.bsherpa.erorreport.exception;
+
+import javax.persistence.EntityExistsException;
+
+public class DuplicatedErrorReportException extends EntityExistsException {
+    public DuplicatedErrorReportException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/exception/ExceptionMessage.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/exception/ExceptionMessage.java
@@ -1,0 +1,6 @@
+package bgaebalja.bsherpa.erorreport.exception;
+
+public class ExceptionMessage {
+    public static final String DUPLICATED_ERROR_REPORT_EXCEPTION_MESSAGE
+            = "이미 신고가 접수된 문항입니다. 전송된 회원 이메일 주소: %s, 전송된 문항 ID: %s";
+}

--- a/src/main/java/bgaebalja/bsherpa/erorreport/repository/ErrorReportRepository.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/repository/ErrorReportRepository.java
@@ -2,6 +2,8 @@ package bgaebalja.bsherpa.erorreport.repository;
 
 import bgaebalja.bsherpa.erorreport.domain.ErrorReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface ErrorReportRepository extends JpaRepository<ErrorReport, Long> {
+    boolean existsByReporterIdAndItemId(@Param("reporter_id") Long reporterId, @Param("item_id") Long itemId);
 }

--- a/src/main/java/bgaebalja/bsherpa/erorreport/service/ErrorReportServiceImpl.java
+++ b/src/main/java/bgaebalja/bsherpa/erorreport/service/ErrorReportServiceImpl.java
@@ -2,13 +2,20 @@ package bgaebalja.bsherpa.erorreport.service;
 
 import bgaebalja.bsherpa.erorreport.domain.ErrorReport;
 import bgaebalja.bsherpa.erorreport.domain.RegisterErrorReportRequest;
+import bgaebalja.bsherpa.erorreport.exception.DuplicatedErrorReportException;
 import bgaebalja.bsherpa.erorreport.repository.ErrorReportRepository;
+import bgaebalja.bsherpa.exception.UserNotFoundException;
 import bgaebalja.bsherpa.file.domain.AddFileRequest;
 import bgaebalja.bsherpa.file.service.FileService;
+import bgaebalja.bsherpa.user.domain.Users;
+import bgaebalja.bsherpa.user.repository.UserRepository;
+import bgaebalja.bsherpa.util.FormatConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static bgaebalja.bsherpa.erorreport.exception.ExceptionMessage.DUPLICATED_ERROR_REPORT_EXCEPTION_MESSAGE;
+import static bgaebalja.bsherpa.exception.ExceptionMessage.USER_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Propagation.NESTED;
 
@@ -16,12 +23,26 @@ import static org.springframework.transaction.annotation.Propagation.NESTED;
 @RequiredArgsConstructor
 public class ErrorReportServiceImpl implements ErrorReportService {
     private final FileService fileService;
+    private final UserRepository userRepository;
     private final ErrorReportRepository errorReportRepository;
 
     @Override
     @Transactional(isolation = READ_COMMITTED, propagation = NESTED, timeout = 20)
     public void createErrorReport(RegisterErrorReportRequest registerErrorReportRequest) {
-        Long id = errorReportRepository.save(ErrorReport.from(registerErrorReportRequest)).getId();
+        String userEmail = registerErrorReportRequest.getUserEmail();
+        Users user = userRepository.findByUserId(userEmail)
+                .orElseThrow(
+                        () -> new UserNotFoundException(String.format(USER_NOT_FOUND_EXCEPTION_MESSAGE, userEmail))
+                );
+        String itemId = registerErrorReportRequest.getItemId();
+        if (errorReportRepository.existsByReporterIdAndItemId(user.getId(), FormatConverter.parseToLong(itemId))) {
+            throw new DuplicatedErrorReportException(
+                    String.format(DUPLICATED_ERROR_REPORT_EXCEPTION_MESSAGE, user.getUserId(), itemId)
+            );
+        }
+        ;
+        Long id = errorReportRepository.save(ErrorReport.from(registerErrorReportRequest, user)).getId();
+
         fileService.createFile(AddFileRequest.from(registerErrorReportRequest, id.toString()));
     }
 }

--- a/src/main/java/bgaebalja/bsherpa/exception/EmailNoValueException.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/EmailNoValueException.java
@@ -1,0 +1,7 @@
+package bgaebalja.bsherpa.exception;
+
+public class EmailNoValueException extends NoValueException {
+    public EmailNoValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/exception/ExceptionMessage.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/ExceptionMessage.java
@@ -18,6 +18,13 @@ public class ExceptionMessage {
 
     public static final String TOKEN_NO_VALUE_EXCEPTION_MESSAGE = "로그인 후 다시 시도해 주세요.";
 
+    public static final String EMAIL_NO_VALUE_EXCEPTION_MESSAGE = "이메일 주소는 필수값입니다.";
+    public static final String INVALID_EMAIL_EXCEPTION_MESSAGE
+            = "이메일 주소 형식이 잘못되었습니다. 예: abcd@abc.com\n전송된 이메일 주소: %s";
+
+    public static final String USER_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 회원을 찾을 수 없습니다. 전송된 회원 이메일 주소: %s";
+
     public static final String ID_NO_VALUE_EXCEPTION_MESSAGE = "ID는 필수값입니다.";
     public static final String INVALID_ID_EXCEPTION_MESSAGE = "ID는 양의 정수(1 이상의 숫자값)여야 합니다. 전송된 ID: %s";
 }

--- a/src/main/java/bgaebalja/bsherpa/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
@@ -158,6 +159,17 @@ public class GlobalExceptionHandler {
 
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
+                .message(e.getMessage())
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+    }
+
+    @ExceptionHandler(EntityExistsException.class)
+    private ResponseEntity<ErrorResponse> handleEntityExistsException(EntityExistsException e) {
+        log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(HttpStatus.CONFLICT.value())
                 .message(e.getMessage())
                 .build();
         return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));

--- a/src/main/java/bgaebalja/bsherpa/exception/InvalidEmailException.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/InvalidEmailException.java
@@ -1,0 +1,7 @@
+package bgaebalja.bsherpa.exception;
+
+public class InvalidEmailException extends InvalidValueException {
+    public InvalidEmailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/exception/UserNotFoundException.java
+++ b/src/main/java/bgaebalja/bsherpa/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package bgaebalja.bsherpa.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class UserNotFoundException extends EntityNotFoundException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/bsherpa/question/domain/CreateQuestionRequest.java
+++ b/src/main/java/bgaebalja/bsherpa/question/domain/CreateQuestionRequest.java
@@ -3,14 +3,14 @@ package bgaebalja.bsherpa.question.domain;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
+import static bgaebalja.bsherpa.util.RequestConstant.ITEM_ID_EXAMPLE;
+import static bgaebalja.bsherpa.util.RequestConstant.ITEM_ID_VALUE;
+
 /**
  * 모두 String 타입으로 받은 후 타입 변환
  */
 @Getter
 public class CreateQuestionRequest {
-    private static final String ITEM_ID_VALUE = "문제 ID";
-    private static final String ITEM_ID_EXAMPLE = "494519";
-
     private static final String DESCRIPTION_URL_VALUE = "해설 URL";
     private static final String DESCRIPTION_URL_EXAMPLE
             = "https://ddipddipddip.s3.amazonaws.com/post/1819/1729131706204_Loopy2.png?w=248&fit=crop&auto=format";

--- a/src/main/java/bgaebalja/bsherpa/util/FormatValidator.java
+++ b/src/main/java/bgaebalja/bsherpa/util/FormatValidator.java
@@ -1,15 +1,26 @@
 package bgaebalja.bsherpa.util;
 
+import bgaebalja.bsherpa.exception.EmailNoValueException;
 import bgaebalja.bsherpa.exception.IdNoValueException;
+import bgaebalja.bsherpa.exception.InvalidEmailException;
 import bgaebalja.bsherpa.exception.InvalidIdException;
 
 import java.util.List;
 
-import static bgaebalja.bsherpa.exception.ExceptionMessage.ID_NO_VALUE_EXCEPTION_MESSAGE;
-import static bgaebalja.bsherpa.exception.ExceptionMessage.INVALID_ID_EXCEPTION_MESSAGE;
+import static bgaebalja.bsherpa.exception.ExceptionMessage.*;
+import static bgaebalja.bsherpa.util.RegularExpressionConstant.EMAIL_PATTERN;
 import static bgaebalja.bsherpa.util.RegularExpressionConstant.POSITIVE_OR_ZERO_INTEGER_PATTERN;
 
 public class FormatValidator {
+    public static void validateEmail(String email) {
+        if (!hasValue(email)) {
+            throw new EmailNoValueException(EMAIL_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+        if (!isValid(email, EMAIL_PATTERN)) {
+            throw new InvalidEmailException(String.format(INVALID_EMAIL_EXCEPTION_MESSAGE + email));
+        }
+    }
+
     public static void validatePositiveOrZeroInteger(String positiveOrZeroInteger) {
         if (!hasValue(positiveOrZeroInteger)) {
             throw new IdNoValueException(ID_NO_VALUE_EXCEPTION_MESSAGE);

--- a/src/main/java/bgaebalja/bsherpa/util/RegularExpressionConstant.java
+++ b/src/main/java/bgaebalja/bsherpa/util/RegularExpressionConstant.java
@@ -1,5 +1,6 @@
 package bgaebalja.bsherpa.util;
 
 public class RegularExpressionConstant {
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String POSITIVE_OR_ZERO_INTEGER_PATTERN = "^([0-9]\\d*)$";
 }

--- a/src/main/java/bgaebalja/bsherpa/util/RequestConstant.java
+++ b/src/main/java/bgaebalja/bsherpa/util/RequestConstant.java
@@ -8,6 +8,10 @@ public class RequestConstant {
     public static final String APPLICATION_JSON = "application/json";
 
     public static final String ID_EXAMPLE = "1";
+    public static final String EMAIL_EXAMPLE = "abc@abc.com";
+
+    public static final String ITEM_ID_VALUE = "문제 ID";
+    public static final String ITEM_ID_EXAMPLE = "494519";
 
     public static final String EXAM_ID = "examId";
     public static final String SUBJECT_ID = "subjectId";


### PR DESCRIPTION
## resolve #127

### 중복 이메일 확인
- 중복 오류 신고 확인 비즈니스 로직
- error_report 테이블에서 회원 이메일 주소와 문항 ID를 통해 중복 오류 신고인지 확인
- 중복 시 DuplicatedErrorReportException 예외 발생
- 409(CONFLICT) status code 응답

### 예외
- 이메일 패턴 예외 처리
    - FormatValidator 클래스에 validateEmail 메서드 추가
    - 커스텀 예외: NoValueException 클래스를 상속하는 EmailNoValueException 클래스
    - 커스텀 예외 메시지: EMAIL_NO_VALUE_EXCEPTION_MESSAGE
    - 커스텀 예외: InvalidValueException 클래스를 상속하는 InvalidEmailException 클래스
    - 커스텀 예외 메시지: INVALID_EMAIL_EXCEPTION_MESSAGE
- 존재하지 않는 사용자 예외 처리
    - 커스텀 예외: EntityNotFoundException 클래스를 상속하는 UserNotFoundException 클래스
    - 커스텀 예외 메시지: USER_NOT_FOUND_EXCEPTION_MESSAGE
- 중복 오류 신고 확인 예외 처리
    - 커스텀 예외: EntityExistsException 클래스를 상속하는 DuplicatedErrorReportException 클래스
    - 커스텀 예외 메시지: DUPLICATED_ERROR_REPORT_EXCEPTION_MESSAGE
- GlobalExceptionHandler 클래스에 EntityExistsException 클래스 처리 로직 추가